### PR TITLE
Fix strict checking of top priority bit in CAN frame receivers

### DIFF
--- a/src/openlcb/DatagramCan.cxx
+++ b/src/openlcb/DatagramCan.cxx
@@ -134,11 +134,9 @@ public:
     enum
     {
         CAN_FILTER = CanMessageData::CAN_EXT_FRAME_FILTER |
-            (CanDefs::NMRANET_MSG << CanDefs::FRAME_TYPE_SHIFT) |
-            (CanDefs::NORMAL_PRIORITY << CanDefs::PRIORITY_SHIFT),
+            (CanDefs::NMRANET_MSG << CanDefs::FRAME_TYPE_SHIFT),
         CAN_MASK = CanMessageData::CAN_EXT_FRAME_MASK |
-            CanDefs::FRAME_TYPE_MASK | CanDefs::PRIORITY_MASK |
-            CanDefs::CAN_FRAME_TYPE_MASK,
+            CanDefs::FRAME_TYPE_MASK | CanDefs::CAN_FRAME_TYPE_MASK,
     };
 
     CanDatagramParser(IfCan *iface);

--- a/src/openlcb/IfCan.cxx
+++ b/src/openlcb/IfCan.cxx
@@ -492,11 +492,9 @@ public:
     {
         CAN_FILTER = CanMessageData::CAN_EXT_FRAME_FILTER |
             (CanDefs::GLOBAL_ADDRESSED << CanDefs::CAN_FRAME_TYPE_SHIFT) |
-            (CanDefs::NMRANET_MSG << CanDefs::FRAME_TYPE_SHIFT) |
-            (CanDefs::NORMAL_PRIORITY << CanDefs::PRIORITY_SHIFT),
+            (CanDefs::NMRANET_MSG << CanDefs::FRAME_TYPE_SHIFT),
         CAN_MASK = CanMessageData::CAN_EXT_FRAME_MASK |
             CanDefs::CAN_FRAME_TYPE_MASK | CanDefs::FRAME_TYPE_MASK |
-            CanDefs::PRIORITY_MASK |
             (Defs::MTI_ADDRESS_MASK << CanDefs::MTI_SHIFT)
     };
 
@@ -571,11 +569,9 @@ public:
         CAN_FILTER = CanMessageData::CAN_EXT_FRAME_FILTER |
             (CanDefs::GLOBAL_ADDRESSED << CanDefs::CAN_FRAME_TYPE_SHIFT) |
             (CanDefs::NMRANET_MSG << CanDefs::FRAME_TYPE_SHIFT) |
-            (CanDefs::NORMAL_PRIORITY << CanDefs::PRIORITY_SHIFT) |
             (Defs::MTI_ADDRESS_MASK << CanDefs::MTI_SHIFT),
         CAN_MASK = CanMessageData::CAN_EXT_FRAME_MASK |
             CanDefs::CAN_FRAME_TYPE_MASK | CanDefs::FRAME_TYPE_MASK |
-            CanDefs::PRIORITY_MASK |
             (Defs::MTI_ADDRESS_MASK << CanDefs::MTI_SHIFT)
     };
 

--- a/src/openlcb/IfCan.cxxtest
+++ b/src/openlcb/IfCan.cxxtest
@@ -395,6 +395,24 @@ TEST_F(AsyncMessageCanTests, WriteByMTIIgnoreDatagram)
     ifCan_->global_message_write_flow()->send(b);
 }
 
+TEST_F(AsyncMessageCanTests, GlobalMessageWithZeroPriority)
+{
+    StrictMock<MockMessageHandler> h;
+    EXPECT_CALL(
+        h, handle_message(
+               Pointee(AllOf(Field(&GenMessage::mti, Defs::MTI_EVENT_REPORT),
+                             Field(&GenMessage::payload,
+                                   IsBufferValue(UINT64_C(0x0102030405060708))))),
+               _));
+    ifCan_->dispatcher()->register_handler(&h, 0, 0);
+
+    // X095B422A is the same as X195B422A but with priority bit cleared.
+    // 0x095B422A is 0x195B422A & ~0x10000000
+    send_packet(":X095B422AN0102030405060708;");
+    wait();
+    ifCan_->dispatcher()->unregister_handler(&h, 0, 0);
+}
+
 TEST_F(AsyncMessageCanTests, WriteByMTIGlobalDoesLoopback)
 {
     StrictMock<MockMessageHandler> h;


### PR DESCRIPTION
Fix issue where OpenMRN rejects CAN frames that have the top priority bit set to 0.

- Removes `CanDefs::PRIORITY_MASK` from `CAN_MASK` and `CanDefs::NORMAL_PRIORITY` from `CAN_FILTER` in `src/openlcb/IfCan.cxx` and `src/openlcb/DatagramCan.cxx`
- Adds a test `GlobalMessageWithZeroPriority` to `src/openlcb/IfCan.cxxtest` to verify that frames with priority bit 0 are successfully processed.

---
*PR created automatically by Jules for task [9691054517968336133](https://jules.google.com/task/9691054517968336133) started by @balazsracz*